### PR TITLE
ranking api

### DIFF
--- a/src/bossraid/bossraid.controller.ts
+++ b/src/bossraid/bossraid.controller.ts
@@ -6,6 +6,7 @@ import { HttpService } from '@nestjs/axios'
 import { firstValueFrom, map, Observable } from 'rxjs';
 import Redis from 'ioredis'
 import { InjectRedis } from '@liaoliaots/nestjs-redis'
+import { BossraidRankDto } from './dto/get-bossraidRank.dto';
 
 @Controller('bossraid')
 export class BossraidController {
@@ -43,5 +44,27 @@ export class BossraidController {
     const { userId, recordId } = updateBossraidDto
     return await this.bossraidService.raidEnd(userId, recordId, redisScore);
     
+  }
+  @Get('/topLankerList')
+  async rank(
+    @Body(ValidationPipe) userInfo: BossraidRankDto
+  ) {
+    try{
+      const array = [];
+      const rank = await this.redis.zrange('rank', 0, 5, 'WITHSCORES');
+      for(let i = rank.length / 2; i > 0; i--) {
+        const rankInfo = {
+          'ranking': rank.length / 2 - i,
+          'userId': rank[2*i - 2],
+          'totalScore': rank[(2*i - 1)]
+        }
+        array.push(rankInfo)
+      }
+      const myId = Object.values(userInfo)[0]
+      const myRank = await this.redis.zrank('rank', myId)
+      return Object.assign({'topRankerInfoList': array, 'myRankingInfo': myRank})
+    } catch(err){
+      console.log(err)
+    }
   }
 }

--- a/src/bossraid/bossraid.service.ts
+++ b/src/bossraid/bossraid.service.ts
@@ -9,6 +9,7 @@ import { Users, UsersRepository } from 'src/users/entities/user.entity';
 
 const moment = require('moment-timezone')
 moment.tz.setDefault("Asia/Seoul")
+const LimitTime = Number(process.env.LIMIT_TIME)
 
 @Injectable()
 export class BossraidService {
@@ -80,7 +81,7 @@ export class BossraidService {
     const id = find[0].id
     const userId = find[0].userId;
     const enterTime = find[0].enter_time;
-    if(Date.now()/1000 > Math.floor(enterTime/1000 + (1 * 60))){
+    if(Date.now()/1000 > Math.floor(enterTime/1000 + LimitTime)){
       const endUpdate = await this.raidHistoriesRepository.findOneBy({id: id});
       endUpdate.end_time = new Date();
       endUpdate.score = 0;
@@ -109,7 +110,7 @@ export class BossraidService {
     const beforeTotalScore = Number(record[0].total)
     const newTotalScore = (beforeTotalScore + Number(redisScore))
     
-      if(Date.now()/1000 < Math.floor(enterTime/1000 + (1 * 60))) {
+      if(Date.now()/1000 < Math.floor(enterTime/1000 + LimitTime)) {
             await this.raidHistoriesRepository
             .createQueryBuilder()
             .update('userhistories')

--- a/src/bossraid/dto/get-bossraidRank.dto.ts
+++ b/src/bossraid/dto/get-bossraidRank.dto.ts
@@ -1,0 +1,6 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class BossraidRankDto {
+    @IsNumber()
+    userId: number;
+}


### PR DESCRIPTION
# 구현사항
- 랭킹 확인 api
  - body에 userId를 입력하여 전송합니다.
  - redis에 저장된 유저목록을 조회합니다.
  - 현재까지 플레이한 유저의 total score를 기준으로 상위 6명을 표시합니다.
  - 현재 나의 순위를 표시합니다.(나의 점수가 없는 경위 null 로 표시됩니다.)


